### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build solution and run tests
+      run: dotnet test


### PR DESCRIPTION
Contributes to #6

As mentioned in #6, the Roslyn tests fail and also take a very long time to run. This CI build does not run them. This will at least catch solution build failures and remaining tests, which is a big improvement over where we were before.